### PR TITLE
Some very rough and ready testing to try to find out why you can uplo…

### DIFF
--- a/pyscicat/client.py
+++ b/pyscicat/client.py
@@ -101,16 +101,30 @@ class ScicatClient:
     ):
         """sends a command to the SciCat API server using url and token, returns the response JSON
         Get token with the getToken method"""
-        return requests.request(
-            method=cmd,
-            url=urljoin(self._base_url, endpoint),
-            json=data.dict(exclude=exclude_fields,exclude_none=True,exclude_unset=True) if data is not None else None,
-            params={"access_token": self._token},
-            headers=self._headers,
-            timeout=self._timeout_seconds,
-            stream=False,
-            verify=True,
-        )
+        if type(data) == dict:
+            return requests.request(
+                method=cmd,
+                url=urljoin(self._base_url, endpoint),
+                json=data if data is not None else None,
+                params={"access_token": self._token},
+                headers=self._headers,
+                timeout=self._timeout_seconds,
+                stream=False,
+                verify=True,
+            )
+
+        else:
+
+            return requests.request(
+                method=cmd,
+                url=urljoin(self._base_url, endpoint),
+                json=data.dict(exclude=exclude_fields,exclude_none=True,exclude_unset=True) if data is not None else None,
+                params={"access_token": self._token},
+                headers=self._headers,
+                timeout=self._timeout_seconds,
+                stream=False,
+                verify=True,
+            )
 
 
     def _call_endpoint(
@@ -1024,9 +1038,9 @@ def get_token(base_url, username, password):
     if response.ok:
         return response.json()["id"]  # not sure if semantically correct
 
-    response = _log_in_via_auth_msad(base_url, username, password)
-    if response.ok:
-        return response.json()["access_token"]
+    # response = _log_in_via_auth_msad(base_url, username, password)
+    # if response.ok:
+    #     return response.json()["access_token"]
 
     err = response.json()["error"]
     logger.error(

--- a/pyscicat/model.py
+++ b/pyscicat/model.py
@@ -115,7 +115,7 @@ class Dataset(Ownable):
     creationTime: str  # datetime
     datasetName: Optional[str]
     description: Optional[str]
-    history: Optional[List[dict]]  # list of foreigh key ids to the Messages table
+    history: Optional[List[dict]]  # list of foreign key ids to the Messages table
     instrumentId: Optional[str]
     isPublished: Optional[bool] = False
     keywords: Optional[List[str]]
@@ -131,10 +131,11 @@ class Dataset(Ownable):
     sourceFolder: str
     sourceFolderHost: Optional[str]
     techniques: Optional[List[dict]]  # with {'pid':pid, 'name': name} as entries
-    type: DatasetType
+    type: str
     validationStatus: Optional[str]
     version: Optional[str]
     scientificMetadata: Optional[Dict]
+
 
 
 class RawDataset(Dataset):

--- a/tests/test_pyscicat/tests_local.py
+++ b/tests/test_pyscicat/tests_local.py
@@ -1,8 +1,9 @@
 from pyscicat.client import ScicatClient
-from pyscicat.model import RawDataset
+from pyscicat.model import RawDataset, Dataset, DatasetType
 from datetime import datetime
 import os
-
+import requests
+import json
 
 """
 These test_pyscicat do not use mocks and are designed to connect
@@ -18,28 +19,28 @@ SCICAT_USER - the name of your scicat user.
 SCICAT_PASSWORD - the password for your scicat user.
 """
 
-
+sci_clie = ScicatClient(base_url=os.environ["BASE_URL"],
+                        token=None,
+                        username=os.environ["SCICAT_USER"],
+                        password=os.environ["SCICAT_PASSWORD"])
 def test_client():
-    sci_clie = ScicatClient(base_url=os.environ["BASE_URL"],
-                            token=None,
-                            username=os.environ["SCICAT_USER"],
-                            password=os.environ["SCICAT_PASSWORD"])
+
     assert type(sci_clie) == ScicatClient
 
 
-def test_upload_dataset():
-    sci_clie = ScicatClient(base_url=os.environ["BASE_URL"],
-                            token=None, username=os.environ["SCICAT_USER"],
-                            password=os.environ["SCICAT_PASSWORD"])
+def test_upload_dataset_requests():
 
+    """ Testing if we can see a dataset in Scicat if it has been uploaded via requests but has been created via RawDataset model
+      """
     payload = RawDataset(
         datasetName="a guide book",
         path="/foo/bar",
         size=42,
+        packedSize=0,
         owner=os.environ["SCICAT_USER"],
-        ownerGroup="Magrateheans",
+        ownerGroup="Magratheans",
         contactEmail="slartibartfast@magrathea.org",
-        creationLocation="magrathea",
+        creationLocation="Magrathea",
         creationTime=datetime.isoformat(datetime.now()),
         instrumentId="earth",
         proposalId="deepthought",
@@ -48,44 +49,137 @@ def test_upload_dataset():
         sourceFolder="/foo/bar",
         scientificMetadata={"a": "field"},
         sampleId="gargleblaster",
-        accessGroups=[]
+        accessGroups=[],
+        type="raw",
+        ownerEmail="scicatingestor@your.site",
+        sourceFolderHost="s3.heartofgold.org",
+        endTime=datetime.isoformat(datetime.now()),
+        techniques = [],
+        numberOfFiles=0,
+        numberOfFilesArchived=0
     )
 
-    sci_clie.upload_new_dataset(payload)
 
 
-def test_get_dataset(subtests):
+    r = requests.request("post", os.environ["BASE_URL"] + '/auth/login', json=dict(username='ingestor', password='aman'))
+
+    token = r.json()['id']
+
+    prep_dict ={ k: v if v is not None else "None" for k, v in  payload.dict().items()}
+
+    drop_list = ["updatedAt", "createdBy", "pid", "updatedBy", "createdAt", "history"]
+    for k in drop_list:
+      del prep_dict[k]
+
+    r = requests.request('post', os.environ["BASE_URL"] + '/datasets', json= prep_dict,
+                         headers={'Authorization': f'Bearer {token}'})
+    print(r)
+
+    q = requests.request('get', os.environ["BASE_URL"] + '/Datasets',
+                         headers={'Authorization': f'Bearer {sci_clie._token}'})
+
+    assert payload["datasetName"] in q.text
+
+
+def test_upload_dataset_sci_cli():
+    """ Testing if we can see a dataset in Scicat if it has been uploaded via pyscicat but is created from a dictionary.
+    had to change _send_to_scicat so that it does not try to cast a dictionary to a dictionary.
+    """
     sci_clie = ScicatClient(base_url=os.environ["BASE_URL"],
-                            token=None,
-                            username=os.environ["SCICAT_USER"],
+                            token=None, username=os.environ["SCICAT_USER"],
                             password=os.environ["SCICAT_PASSWORD"])
-    datasets = sci_clie.get_datasets({"ownerGroup": "Magratheans"})
-    for dataset in datasets:
-        with subtests.tests(dataset=dataset):
-            assert dataset["ownerGroup"] == "Magratheans"
+    payload ={
+        "owner": "ingestor",
+        "ownerGroup": "Magratheans",
+        "accessGroups": [],
+        "dataFormat": "directory",
+        "principalInvestigator": "slartibartfast",
+        "endTime": "2020-04-08T08:10:07.553Z",
+        "creationLocation": "my_test_instrument",
+        "scientificMetadata": {},
+        "owner": "ingestor",
+        "ownerEmail": "slartibartfast@magrathea.com",
+        "orcidOfOwner": "https://orcid.org/0000-0000-0000-0000",
+        "contactEmail": "scicatingestor@org.org",
+        "sourceFolder": "new_test_4.txt",
+        "sourceFolderHost": "s3.amazonaws.com",
+        "size": 0,
+        "packedSize": 0,
+        "creationTime": "2023-03-08T08:10:06.713Z",
+        "type": "raw",
+        "validationStatus": "string",
+        "keywords": [],
+        "description": "Description of my example dataset.",
+        "datasetName": "Example Dataset",
+        "classification": "AV=medium,CO=low",
+        "license": "string",
+        "version": "rfi-file-monitor-0.2.0:extensions-0.1.3",
+        "isPublished": True,
+        "datasetlifecycle": {
+            "archivable": True,
+            "retrievable": True,
+            "publishable": True,
+            "dateOfDiskPurging": "2020-04-08T08:10:06.713Z",
+            "archiveRetentionTime": "2020-04-08T08:10:06.713Z",
+            "dateOfPublishing": "2020-04-08T08:10:06.713Z",
+            "isOnCentralDisk": True,
+            "archiveStatusMessage": "archive job sent",
+            "retrieveStatusMessage": "retrieve job sent",
+            "archiveReturnMessage": {},
+            "retrieveReturnMessage": {},
+            "exportedTo": "string",
+            "retrieveIntegrityCheck": True
+        },
+        # "history": [],
+        "instrumentId": "string",
+        "techniques": [
+            {
+                "pid": "string",
+                "name": "Example technique"
+            }
+        ]}
+
+    sci_clie._call_endpoint('post', 'Datasets', payload)
+
+    r = requests.request('get', os.environ["BASE_URL"] + '/Datasets',
+                         headers={'Authorization': f'Bearer {sci_clie._token}'})
+
+    assert payload["datasetName"] in r.text
+    print(r.text)
 
 
-def test_update_dataset():
-    sci_clie = ScicatClient(base_url=os.environ["BASE_URL"],
-                            token=None,
-                            username=os.environ["SCICAT_USER"],
-                            password=os.environ["SCICAT_PASSWORD"])
+# def test_get_dataset(subtests):
+#     sci_clie = ScicatClient(base_url=os.environ["BASE_URL"],
+#                             token=None,
+#                             username=os.environ["SCICAT_USER"],
+#                             password=os.environ["SCICAT_PASSWORD"])
+#     datasets = sci_clie.get_datasets({"owner": "ingestor"})
+#     for dataset in datasets:
+#         with subtests.tests(dataset=dataset):
+#             assert dataset["ownerGroup"] == "Magratheans"
 
-    pid = "PID.SAMPLE.PREFIX48a8f164-166a-4557-bafc-5a7362e39fe7"
-    payload = RawDataset(
-        size=142,
-        owner="slartibartfast",
-        ownerGroup="Magrateheans",
-        contactEmail="slartibartfast@magrathea.org",
-        creationLocation="magrathea",
-        creationTime=datetime.isoformat(datetime.now()),
-        instrumentId="earth",
-        proposalId="deepthought",
-        dataFormat="planet",
-        principalInvestigator="A. Mouse",
-        sourceFolder="/foo/bar",
-        scientificMetadata={"a": "field"},
-        sampleId="gargleblaster",
-        accessGroups=["Vogons"]
-    )
-    sci_clie.update_dataset(payload, pid)
+
+# def test_update_dataset():
+#     sci_clie = ScicatClient(base_url=os.environ["BASE_URL"],
+#                             token=None,
+#                             username=os.environ["SCICAT_USER"],
+#                             password=os.environ["SCICAT_PASSWORD"])
+#
+#
+#     payload = RawDataset(
+#         size=142,
+#         owner="slartibartfast",
+#         ownerGroup="Magrateheans",
+#         contactEmail="slartibartfast@magrathea.org",
+#         creationLocation="magrathea",
+#         creationTime=datetime.isoformat(datetime.now()),
+#         instrumentId="earth",
+#        #proposalId="deepthought",
+#         dataFormat="planet",
+#         principalInvestigator="A. Mouse",
+#         sourceFolder="/foo/bar",
+#         scientificMetadata={"a": "field"},
+#         sampleId="gargleblaster",
+#         accessGroups=["Vogons"]
+#     )
+#     sci_clie.update_dataset(payload, pid)

--- a/tests/test_pyscicat/tests_local.py
+++ b/tests/test_pyscicat/tests_local.py
@@ -1,5 +1,5 @@
 from pyscicat.client import ScicatClient
-from pyscicat.model import RawDataset, Dataset, DatasetType
+from pyscicat.model import RawDataset, Ownable, Dataset, DatasetType
 from datetime import datetime
 import os
 import requests
@@ -32,31 +32,32 @@ def test_upload_dataset_requests():
 
     """ Testing if we can see a dataset in Scicat if it has been uploaded via requests but has been created via RawDataset model
       """
+
+    ownable = Ownable( ownerGroup="Magratheans", accessGroups=[])
     payload = RawDataset(
-        datasetName="a guide book",
+        datasetName="a new guide book",
         path="/foo/bar",
         size=42,
         packedSize=0,
         owner=os.environ["SCICAT_USER"],
-        ownerGroup="Magratheans",
         contactEmail="slartibartfast@magrathea.org",
         creationLocation="Magrathea",
-        creationTime=datetime.isoformat(datetime.now()),
+        creationTime=datetime.strftime(datetime.now(), format="%y-%m-%dT%H:%M:%S.%sZ"),
         instrumentId="earth",
         proposalId="deepthought",
         dataFormat="planet",
         principalInvestigator="A. Mouse",
         sourceFolder="/foo/bar",
-        scientificMetadata={"a": "field"},
+        scientificMetadata={"type": "string", "value":{"a": "field"}},
         sampleId="gargleblaster",
-        accessGroups=[],
         type="raw",
         ownerEmail="scicatingestor@your.site",
         sourceFolderHost="s3.heartofgold.org",
         endTime=datetime.isoformat(datetime.now()),
         techniques = [],
         numberOfFiles=0,
-        numberOfFilesArchived=0
+        numberOfFilesArchived=0,
+        **ownable.dict()
     )
 
 
@@ -71,14 +72,17 @@ def test_upload_dataset_requests():
     for k in drop_list:
       del prep_dict[k]
 
-    r = requests.request('post', os.environ["BASE_URL"] + '/datasets', json= prep_dict,
+    r = requests.request('post', os.environ["BASE_URL"] + '/datasets', json= payload.dict(exclude_none=True),
                          headers={'Authorization': f'Bearer {token}'})
-    print(r)
+   # r = requests.request('post', os.environ["BASE_URL"] + '/datasets', json= prep_dict,
+   #                      headers={'Authorization': f'Bearer {token}'})
+    # with open("prep_dict.json", 'w') as f:
+    #     json.dump(prep_dict, f)
 
     q = requests.request('get', os.environ["BASE_URL"] + '/Datasets',
                          headers={'Authorization': f'Bearer {sci_clie._token}'})
 
-    assert payload["datasetName"] in q.text
+    assert payload.datasetName in q.text
 
 
 def test_upload_dataset_sci_cli():
@@ -88,7 +92,8 @@ def test_upload_dataset_sci_cli():
     sci_clie = ScicatClient(base_url=os.environ["BASE_URL"],
                             token=None, username=os.environ["SCICAT_USER"],
                             password=os.environ["SCICAT_PASSWORD"])
-    payload ={
+
+    payload = {
         "owner": "ingestor",
         "ownerGroup": "Magratheans",
         "accessGroups": [],
@@ -147,6 +152,72 @@ def test_upload_dataset_sci_cli():
     assert payload["datasetName"] in r.text
     print(r.text)
 
+def test_minimal_upload():
+    """ Creating a minimal payload to see if we can replicate the error we are getting in raw dataset.
+    """
+    sci_clie = ScicatClient(base_url=os.environ["BASE_URL"],
+                            token=None, username=os.environ["SCICAT_USER"],
+                            password=os.environ["SCICAT_PASSWORD"])
+    payload = {
+        "owner": "ingestor",
+        "ownerGroup": "Magratheans",
+        "accessGroups": [],
+        "dataFormat": "directory",
+        "principalInvestigator": "slartibartfast",
+        # "endTime": "2020-04-08T08:10:07.553Z",
+        "creationLocation": "my_test_instrument",
+        # "scientificMetadata": {},
+        "owner": "ingestor",
+        #  "ownerEmail": "slartibartfast@magrathea.com",
+        # "orcidOfOwner": "https://orcid.org/0000-0000-0000-0000",
+        "contactEmail": "scicatingestor@org.org",
+        "sourceFolder": "new_test_4.txt",
+        # "sourceFolderHost": "s3.amazonaws.com",
+        "size": 0,
+        # "packedSize": 0,
+        "creationTime": "2023-03-08T08:10:06.713Z",
+        "type": "raw",
+        # "validationStatus": "string",
+        # "keywords": [],
+        # "description": "Description of my example dataset.",
+        "datasetName": "Minimal Dataset",
+        # "classification": "AV=medium,CO=low",
+        # "license": "string",
+        # "version": "rfi-file-monitor-0.2.0:extensions-0.1.3",
+        # "isPublished": True,
+        # "datasetlifecycle": {
+        #     "archivable": True,
+        #     "retrievable": True,
+        #     "publishable": True,
+        #     "dateOfDiskPurging": "2020-04-08T08:10:06.713Z",
+        #     "archiveRetentionTime": "2020-04-08T08:10:06.713Z",
+        #     "dateOfPublishing": "2020-04-08T08:10:06.713Z",
+        #     "isOnCentralDisk": True,
+        #     "archiveStatusMessage": "archive job sent",
+        #     "retrieveStatusMessage": "retrieve job sent",
+        #     "archiveReturnMessage": {},
+        #     "retrieveReturnMessage": {},
+        #     "exportedTo": "string",
+        #     "retrieveIntegrityCheck": True
+        # },
+        # # "history": [],
+        # "instrumentId": "string",
+        # "techniques": [
+        #     {
+        #         "pid": "string",
+        #         "name": "Example technique"
+        #     }
+        #     ]
+    }
+
+    with open("native_dict.json", 'w') as f:
+        json.dump(payload, f)
+
+    sci_clie._call_endpoint('post', 'Datasets', payload)
+
+    r = requests.request('get', os.environ["BASE_URL"] + '/Datasets',
+                         headers={'Authorization': f'Bearer {sci_clie._token}'})
+
 
 # def test_get_dataset(subtests):
 #     sci_clie = ScicatClient(base_url=os.environ["BASE_URL"],
@@ -183,3 +254,5 @@ def test_upload_dataset_sci_cli():
 #         accessGroups=["Vogons"]
 #     )
 #     sci_clie.update_dataset(payload, pid)
+
+


### PR DESCRIPTION
…ad data into the new scicat backend with pyscicat, but you cannot read it.

I wanted to check if this was an auth error or an error parsing the RawDataset model. I created two tests : 1) `test_upload_dataset_requests()` which uploaded a RawDataset model via the requests protocol 2) `test_upload_dataset_sci_cli()` which uploaded a dictionary using the ScicatClient. I had to change the _send_to_scicat method to allow upload of dictionaries.

I found that method 2 can ingest to scicat in a way that the API can read the data. Method 1 will ingest the dataset but the Scicat API cannot read it.